### PR TITLE
Potentially fix setuptools-git-versioning runtime error.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 setuptools
-typing
+typing;python_version<"3.5"


### PR DESCRIPTION
```
    ERROR: Command errored out with exit status 1:
     command: 'L:\GIT\descriptx\.venv\Scripts\python.exe' -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\lollo\\AppData\\Local\\Temp\\pip-req-build-ozqrg_4h\\setup.py'"'"'; __file__='"'"'C:\\Users\\lollo\\AppData\\Local\\Temp\\pip-req-build-ozqrg_4h\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base 'C:\Users\lollo\AppData\Local\Temp\pip-pip-egg-info-chp_c1eu'
         cwd: C:\Users\lollo\AppData\Local\Temp\pip-req-build-ozqrg_4h\
    Complete output (27 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\lollo\AppData\Local\Temp\pip-req-build-ozqrg_4h\setup.py", line 4, in <module>
        setup(
      File "L:\GIT\descriptx\.venv\lib\site-packages\setuptools\__init__.py", line 165, in setup
        return distutils.core.setup(**attrs)
      File "c:\program files\python\3.8\lib\distutils\core.py", line 108, in setup
        _setup_distribution = dist = klass(attrs)
      File "L:\GIT\descriptx\.venv\lib\site-packages\setuptools\dist.py", line 429, in __init__
        _Distribution.__init__(self, {
      File "c:\program files\python\3.8\lib\distutils\dist.py", line 292, in __init__
        self.finalize_options()
      File "L:\GIT\descriptx\.venv\lib\site-packages\setuptools\dist.py", line 721, in finalize_options
        ep(self)
      File "L:\GIT\descriptx\.venv\lib\site-packages\setuptools\dist.py", line 728, in _finalize_setup_keywords
        ep.load()(self, ep.name, value)
      File "L:\GIT\descriptx\.venv\lib\site-packages\pkg_resources\__init__.py", line 2461, in load
        return self.resolve()
      File "L:\GIT\descriptx\.venv\lib\site-packages\pkg_resources\__init__.py", line 2467, in resolve
        module = __import__(self.module_name, fromlist=['__name__'], level=0)
      File "c:\users\lollo\appdata\local\temp\pip-req-build-ozqrg_4h\.eggs\setuptools_git_versioning-1.1.3-py3.8.egg\setuptools_git_versioning.py", line 6, in <module>
        from typing import List, Optional, Any
      File "c:\users\lollo\appdata\local\temp\pip-req-build-ozqrg_4h\.eggs\typing-3.7.4.3-py3.8.egg\typing.py", line 1359, in <module>
        class Callable(extra=collections_abc.Callable, metaclass=CallableMeta):
      File "c:\users\lollo\appdata\local\temp\pip-req-build-ozqrg_4h\.eggs\typing-3.7.4.3-py3.8.egg\typing.py", line 1007, in __new__
        self._abc_registry = extra._abc_registry
    AttributeError: type object 'Callable' has no attribute '_abc_registry'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```