### PR TITLE
fix: python error if no tag is found

### DIFF
--- a/setuptools_git_versioning.py
+++ b/setuptools_git_versioning.py
@@ -152,7 +152,7 @@ def version_from_git(template=DEFAULT_TEMPLATE,
             else:
                 return version_callback
 
-        if not os.path.exists(version_file):
+        if version_file is None or not os.path.exists(version_file):
             return starting_version
         else:
             from_file = True


### PR DESCRIPTION
Using the default_config with only 'starting_version' set in a repository without tags
the following error was raised:

...
File "../project/.eggs/setuptools_git_versioning-1.2.6-py3.7.egg/setuptools_git_versioning.py", line 156, in version_from_git
if not os.path.exists(version_file):
File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/genericpath.py", line 19, in exists
os.stat(path)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```
Python 3.7.3 (on MacOS)