### PR TITLE
support git being run in a different dir

### DIFF
--- a/setuptools_git_versioning.py
+++ b/setuptools_git_versioning.py
@@ -12,11 +12,14 @@ DEFAULT_DEV_TEMPLATE = "{tag}.post{ccount}+git.{sha}"  # type: str
 DEFAULT_DIRTY_TEMPLATE = "{tag}.post{ccount}+git.{sha}.dirty"  # type: str
 DEFAULT_STARTING_VERSION = '0.0.1'
 
+run_in_dir = None
+
 
 def _exec(cmd):  # type: (str) -> List[str]
     try:
         stdout = subprocess.check_output(cmd, shell=True,
-                                         universal_newlines=True)
+                                         universal_newlines=True,
+                                         cwd=run_in_dir)
     except subprocess.CalledProcessError as e:
         stdout = e.output
     lines = stdout.splitlines()
@@ -109,6 +112,8 @@ def parse_config(dist, _, value):  # type: (Distribution, Any, Any) -> None
     version_callback = value.get('version_callback', None)
     version_file = value.get('version_file', None)
     count_commits_from_version_file = value.get('count_commits_from_version_file', False)
+    global run_in_dir
+    run_in_dir = value.get('git_run_in_dir', None)
 
     version = version_from_git(
         template=template,


### PR DESCRIPTION
In cases where the git package is just a directory, for example a git submodule, setup.py will use the tag of the parent git directory.

Something like this would support a new config variable that could be used like this:

```
setuptools.setup(
    ...
    version_config=True,
    setup_requires=['setuptools-git-versioning'],
    git_run_in_dir=os.path.dirname(os.path.realpath(__file__)),
    ...
)
```