### PR TITLE
adding formatting function for branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,11 +335,13 @@ Then you decided to release new version:
 - **Note: every change of this file in the `dev` branch will lead to this `N` suffix to be reset to `0`. Update this file only in the case when you've setting up the next release version!**
 
 
-### Development releases (prereleases) from `feature`/`bugfix` branch
+### Development releases (prereleases) from any branch (`feature`/`bugfix`/`preview`/`beta`/etc)
 
-Just like previous example, but you want to make development releases (prereleases) with using branch name in a version template.
+Just like previous example, but you want to make development releases (prereleases) with a branch name present in the version number.
 
-If branch name is PEP-440 compatible, like `alpha`, `beta`, `preview` or `rc`, you can just set a template you want:
+In case of branch names which are PEP-440 compatible, you can just use `{branch}` substitution in a version template.
+
+For example, if the branch name is something like `alpha`, `beta`, `preview` or `rc`:
 ```python
 setuptools.setup(
     ...
@@ -353,10 +355,25 @@ setuptools.setup(
     ...
 )
 ```
+Adding a commit to the `alpha` branch will generate a version number like `1.2.3.alpha4`, new commit to the `beta` branch will generate a version number like `1.2.3.beta5` and so on.
 
-SO you'll get version number like `1.2.3.alpha4` for commit into an `alpha` branch or `1.2.3.preview4` for commit into a `preview` branch.
+It is also possible to use branch names prefixed with a major version number, like `1.0-alpha` or `1.1.beta`:
+```python
+setuptools.setup(
+    ...
+    version_config={
+        "count_commits_from_version_file": True,
+        "dev_template": "{branch}{ccount}",
+        "dirty_template": "{branch}{ccount}",
+        "version_file": VERSION_FILE
+    },
+    setup_requires=['setuptools-git-versioning'],
+    ...
+)
+```
+Adding a commit to the `1.0-alpha` branch will generate a version number like `1.0.alpha2`, new commit to the `1.2.beta` branch will generate a version number like `1.2.beta3` and so on.
 
-If branch name is not PEP-440 compatible, like `feature/ABC-123` or `bugfix/ABC-123`, you'll get version number which `pip` cannot understand.
+But if branch name is not PEP-440 compatible at all, like `feature/ABC-123` or `bugfix/ABC-123`, you'll get version number which `pip` cannot understand.
 
 To fix that you can define a callback which will receive current branch name and return a propery formatted one:
 ```python

--- a/README.md
+++ b/README.md
@@ -334,6 +334,35 @@ Then you decided to release new version:
 - `N` in `.devN` suffix is a number of commits since the last change of a certain file.
 - **Note: every change of this file in the `dev` branch will lead to this `N` suffix to be reset to `0`. Update this file only in the case when you've setting up the next release version!**
 
+### Create version from formatted branch name
+
+You want to create version from formatted branch name. For example if your branch naming does not match pep440.
+
+You can create a function which formats branch name to create version from it:
+Then set it as branch formatter in your `setup.py` file like example below:
+
+```python
+import re
+# Branch naming is like bugfix/issue-1234-bug-title
+def format_branch_name(branch_name):
+    branch_name_regex_groups = re.search('^(bugfix|feature)\/issue-([0-9]+)-\S+', branch_name)
+    try:
+        return branch_name_regex_groups.group(2)
+    except Exception as e:
+        raise Exception('Unable to compute issue number from branch name: ' + branch_name, e)
+
+setuptools.setup(
+    ...
+    version_config={
+        "dev_template": "{branch}.dev{ccount}",
+        "dirty_template": "{branch}.dev{ccount}",
+        "branch_formatter"=format_branch_name
+    },
+    setup_requires=['setuptools-git-versioning'],
+    ...
+)
+```
+
 ## Options
 
 Default options are:
@@ -348,7 +377,8 @@ setuptools.setup(
         "starting_version": "0.0.1",
         "version_callback": None,
         "version_file": None,
-        "count_commits_from_version_file": False
+        "count_commits_from_version_file": False,
+        "branch_formatter": None
     },
     ...
     setup_requires=['setuptools-git-versioning'],
@@ -369,6 +399,8 @@ setuptools.setup(
 - `version_file`: path to VERSION file, to read version from it instead of using `static_version`
 
 - `count_commits_from_version_file`: `True` to fetch `version_file` last commit instead of tag commit, `False` otherwise
+
+- `branch_formatter`: callback to format branch name before calculating version from it
 
 ### Substitions
 

--- a/setuptools_git_versioning.py
+++ b/setuptools_git_versioning.py
@@ -109,6 +109,7 @@ def parse_config(dist, _, value):  # type: (Distribution, Any, Any) -> None
     version_callback = value.get('version_callback', None)
     version_file = value.get('version_file', None)
     count_commits_from_version_file = value.get('count_commits_from_version_file', False)
+    branch_formatter = value.get('branch_formatter', None)
 
     version = version_from_git(
         template=template,
@@ -117,7 +118,8 @@ def parse_config(dist, _, value):  # type: (Distribution, Any, Any) -> None
         starting_version=starting_version,
         version_callback=version_callback,
         version_file=version_file,
-        count_commits_from_version_file=count_commits_from_version_file
+        count_commits_from_version_file=count_commits_from_version_file,
+        branch_formatter=branch_formatter
     )
     dist.metadata.version = version
 

--- a/setuptools_git_versioning.py
+++ b/setuptools_git_versioning.py
@@ -136,7 +136,7 @@ def version_from_git(template=DEFAULT_TEMPLATE,
                      count_commits_from_version_file=False,
                      branch_formatter=None,
                      ):
-    # type: (str, str, str, str, Optional[Any, Callable], Optional[str], bool,Optional[Callable[[str], str]]) -> str
+    # type: (str, str, str, str, Optional[Any, Callable], Optional[str], bool, Optional[Callable[[str], str]]) -> str
 
     # Check if PKG-INFO exists and return value in that if it does
     if os.path.exists('PKG-INFO'):

--- a/setuptools_git_versioning.py
+++ b/setuptools_git_versioning.py
@@ -133,8 +133,10 @@ def version_from_git(template=DEFAULT_TEMPLATE,
                      starting_version=DEFAULT_STARTING_VERSION,
                      version_callback=None,
                      version_file=None,
-                     count_commits_from_version_file=False
-                     ):  # type: (str, str, str, str, Optional[Any, Callable], Optional[str], bool) -> str
+                     count_commits_from_version_file=False,
+                     branch_formatter=None,
+                     ):
+    # type: (str, str, str, str, Optional[Any, Callable], Optional[str], bool,Optional[Callable[[str], str]]) -> str
 
     # Check if PKG-INFO exists and return value in that if it does
     if os.path.exists('PKG-INFO'):
@@ -171,7 +173,7 @@ def version_from_git(template=DEFAULT_TEMPLATE,
     full_sha = head_sha if head_sha is not None else ''
     ccount = count_since(tag_sha)
     on_tag = head_sha is not None and head_sha == tag_sha and not from_file
-    branch = get_branch()
+    branch = get_branch() if branch_formatter is None else branch_formatter(get_branch())
 
     if dirty:
         t = dirty_template


### PR DESCRIPTION
This PR aims to enable formatting branch names for creating versions. 

Branch name can often be blocking for pep440, in dev mode. For our particular example, we work on branches named with a ticket/issue type (feature, bugfix ..), followed by "/" and the number of the ticket/issue and the title of the ticket/issue. (For example: feature/issue-1234-add-a-great-feature).

We want to create versions based on theses branch names and we need to format them before, for example by taking just the ticket/issue number.