### PR TITLE
Specify build-system dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,13 @@
+[build-system]
+requires = [
+  "setuptools",
+  "wheel",
+  "six>=1.13.0",
+  "toml>=0.10.2",
+  "packaging",
+]
+build-backend = "setuptools.build_meta"
+
 [tool.isort]
 profile = "black"
 multi_line_output = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ multi_line_output = 3
 
 [tool.black]
 line-length = 120
-target-version = ['py27', 'py35', 'py36', 'py37', 'py38', 'py39', 'py310']
+target-version = ['py35', 'py36', 'py37', 'py38', 'py39', 'py310']
 include = '\.pyi?$'
 exclude = '''(\.eggs|\.git|\.mypy_cache|\.tox|\.venv|_build|buck-out|build|dist)'''
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ multi_line_output = 3
 
 [tool.black]
 line-length = 120
-target-version = ['py35', 'py36', 'py37', 'py38', 'py39', 'py310']
+target-version = ['py27', 'py35', 'py36', 'py37', 'py38', 'py39', 'py310']
 include = '\.pyi?$'
 exclude = '''(\.eggs|\.git|\.mypy_cache|\.tox|\.venv|_build|buck-out|build|dist)'''
 

--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(HERE)
 
 
-def infer_version():
-    from setuptools_git_versioning import version_from_git
-
-    return version_from_git()
+from setuptools_git_versioning import version_from_git  # noqa: E402
 
 
 def parse_requirements(file_content):
@@ -26,7 +23,7 @@ with open(os.path.join(HERE, "requirements.txt")) as f:
 
 setup(
     name="setuptools-git-versioning",
-    version=infer_version(),
+    version=version_from_git,
     author="dolfinus",
     author_email="martinov.m.s.8@gmail.com",
     description="Use git repo data for building a version number according PEP-440",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(os.path.join(HERE, "requirements.txt")) as f:
 
 setup(
     name="setuptools-git-versioning",
-    version=version_from_git,
+    version=version_from_git(),
     author="dolfinus",
     author_email="martinov.m.s.8@gmail.com",
     description="Use git repo data for building a version number according PEP-440",

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,16 @@
 import os
-from setuptools import setup, find_packages
-from setuptools_git_versioning import version_from_git
+import sys
+
+from setuptools import find_packages, setup
 
 HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(HERE)
+
+
+def infer_version():
+    from setuptools_git_versioning import version_from_git
+
+    return version_from_git()
 
 
 def parse_requirements(file_content):
@@ -18,7 +26,7 @@ with open(os.path.join(HERE, "requirements.txt")) as f:
 
 setup(
     name="setuptools-git-versioning",
-    version=version_from_git(),
+    version=infer_version(),
     author="dolfinus",
     author_email="martinov.m.s.8@gmail.com",
     description="Use git repo data for building a version number according PEP-440",

--- a/tests/lib/util.py
+++ b/tests/lib/util.py
@@ -147,7 +147,7 @@ def create_pyproject_toml(
             """
         ),
         commit=False,
-        **kwargs
+        **kwargs,
     )
 
     cfg = {}  # type: Dict[str, Any]
@@ -215,7 +215,7 @@ def create_setup_py(
                 coverage.save()
             """
         ).format(cfg=cfg),
-        **kwargs
+        **kwargs,
     )
 
 


### PR DESCRIPTION
Also, only import from internal module on setup.py after adding its path
to pythonpath.

Closes #49.