### PR TITLE
Support running tests in more environments

### DIFF
--- a/setuptools_git_versioning.py
+++ b/setuptools_git_versioning.py
@@ -15,6 +15,11 @@ from pathlib import Path
 from pprint import pformat
 from typing import TYPE_CHECKING, Any, Callable
 
+# because we use distutils in this file, we need to ensure that setuptools is
+# imported first so that it can do monkey patching. this is not always already
+# done for us, for example, when running this in a test or as a module
+import setuptools  # noqa: F401
+
 if TYPE_CHECKING:
     # avoid importing 'packaging' because setuptools-git-versioning can be installed using sdist
     # where 'packaging' is not installed yet

--- a/tests/lib/util.py
+++ b/tests/lib/util.py
@@ -30,6 +30,13 @@ def rand_sha() -> str:
 
 def execute(cwd: str | os.PathLike, cmd: str, **kwargs) -> str:
     log.info(f"Executing '{cmd}' at '{cwd}'")
+
+    if "env" in kwargs:
+        kwargs["env"]["PATH"] = os.environ["PATH"]
+        pythonpath = os.getenv("PYTHONPATH", None)
+        if pythonpath:
+            kwargs["env"]["PYTHONPATH"] = pythonpath
+
     return subprocess.check_output(cmd, cwd=cwd, shell=True, universal_newlines=True, **kwargs)  # nosec
 
 


### PR DESCRIPTION
1. Support running tests in test runners that do not import setuptools prior to running the test.
2. Pass along PATH and PYTHONPATH when running setup.py in a new process with with a new environment.

I'm working on packaging this in [nixpkgs](https://github.com/NixOS/nixpkgs), which does not use virtual environments. Instead, we construct a PYTHONPATH from all depended upon packages, which means we do not always have setuptools available and need that environment variable propagated in child processes.