### PR TITLE
switch to tomli for toml fallback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 packaging
 setuptools
-toml>=0.10.2; python_version<"3.11"
+tomli>=2.0.1; python_version<"3.11"

--- a/setuptools_git_versioning.py
+++ b/setuptools_git_versioning.py
@@ -181,9 +181,10 @@ def _read_toml(name_or_path: str | os.PathLike = "pyproject.toml", root: str | o
         with file_path.open("rb") as file:
             parsed_file = tomllib.load(file)
     except (ImportError, NameError):
-        import toml  # type: ignore[no-redef]
+        import tomli
 
-        parsed_file = toml.load(file_path)
+        with file_path.open("rb") as file:
+            parsed_file = tomli.load(file)
 
     result = parsed_file.get("tool", {}).get("setuptools-git-versioning", None)
     if result:


### PR DESCRIPTION
toml has been abandoned since Nov 1, 2020 and doesn't support some syntax

also tomli is used by pip and setuptools, so this project should match that