### PR TITLE
Fix a small typo in the package description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ setuptools-git-versioning
     :target: https://results.pre-commit.ci/latest/github/dolfinus/setuptools-git-versioning/master
 
 Use git repo data (latest tag, current commit hash, etc) for building a
-version number according :pep:`440`.
+version number according to :pep:`440`.
 
 **Features:**
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     version=version_from_git(root=here, dev_template="{tag}.post{ccount}"),
     author="dolfinus",
     author_email="martinov.m.s.8@gmail.com",
-    description="Use git repo data for building a version number according PEP-440",
+    description="Use git repo data for building a version number according to PEP-440",
     license="MIT",
     long_description=long_description,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
“according PEP-440” → “according to PEP-440”