### PR TITLE
Remove test dependency on unmaintained PyPI toml package

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,5 +2,6 @@ build
 coverage
 pytest
 pytest-rerunfailures
-toml
+# Some tests need to write TOML, but tomli and tomllib are read-only, and toml package is unmaintained
+tomli-w
 wheel

--- a/tests/lib/util.py
+++ b/tests/lib/util.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from secrets import token_hex
 from typing import Any, Callable
 
-import toml
+import tomli_w
 
 log = logging.getLogger(__name__)
 root = Path(__file__).parent.parent
@@ -217,7 +217,7 @@ def create_pyproject_toml(
     if config != NotImplemented:
         cfg["tool"] = {"setuptools-git-versioning": config}
 
-    return create_file(cwd, "pyproject.toml", toml.dumps(cfg), commit=commit, **kwargs)
+    return create_file(cwd, "pyproject.toml", tomli_w.dumps(cfg), commit=commit, **kwargs)
 
 
 def create_setup_py(

--- a/tests/test_integration/test_config.py
+++ b/tests/test_integration/test_config.py
@@ -3,7 +3,7 @@ import subprocess
 import textwrap
 
 import pytest
-import toml
+import tomli_w
 
 from tests.lib.util import (
     create_file,
@@ -66,7 +66,7 @@ def test_config_not_used(repo):
     create_file(
         repo,
         "pyproject.toml",
-        toml.dumps(cfg),
+        tomli_w.dumps(cfg),
     )
 
     assert get_version(repo, isolated=False) == "0.0.0"


### PR DESCRIPTION
Use [`tomli-w`](https://pypi.org/project/tomli-w) for writing TOML instead.

See also https://fedoraproject.org/wiki/Changes/DeprecatePythonToml.